### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,8 @@ All notable changes to the "chromaskin-by-bator" extension will be documented in
 ## 1.1.2
 
 - Fixed problem with widget border opacity.
+
+## 1.1.3
+
+- Improved recovery options with helpful guidance on restoring your personalized settings
+- Further improved visibility of gitignore files with optimized opacity settings

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ ChromaSkin lets you mix and match your favorite syntax highlighting with custom 
     - Preview changes
     - Save your customized theme
 
-> [!TIP] Use the color picker's eyedropper tool to sample colors from anywhere on your screen to fine-tune any UI element
+> **🖱️ Tip:** Use the color picker's eyedropper tool to sample colors from anywhere on your screen to fine-tune any UI element
+
+> **⚠️ Important:** ChromaSkin uses VS Code's global color customizations. If you have existing custom color settings, they may be overwritten when applying a theme. If you haven't customized these settings before, this won't affect you. (In case your settings are overwritten, you can recover them using the "⋯" -> "Export Original Settings" menu option)
 
 ## 🎨 Theme Generator Preview
 

--- a/media/index.hbs
+++ b/media/index.hbs
@@ -121,12 +121,6 @@
                 </div>
 
                 <div class="footer">
-                    {{!-- info message --}}
-                    <div class="info-message warning" {{#if hideInfoMessage}}style="display:none;"{{/if}}>
-                        <span class="warning-icon">⚠️</span>
-                        <p>This extension modifies VS Code's workbench and token color customization settings. If you have existing custom color settings, they may be overwritten when applying a theme. If you haven't customized these settings before, this won't affect you.</p>
-                        <button id="info-message-close" class="info-message-close" aria-label="Close warning message">×</button>
-                    </div>
                     {{!-- button container --}}
                     <div class="button-container">
                         <button id="apply-button" class="apply-button" title="Apply the current color settings to your VS Code theme">Apply Theme</button>
@@ -146,6 +140,21 @@
                             </div>
                         </div>
                         <input type="file" id="import-file-input" accept=".json" style="display: none;" />
+                    </div>
+
+                    {{!-- info message --}}
+                    <div class="info-message warning" {{#if hideInfoMessage}}style="display:none;"{{/if}}>
+                        <span class="warning-icon">⚠️</span>
+                        <p>This extension modifies VS Code's workbench and token color customization settings. If you have existing custom color settings, they may be overwritten when applying a theme. If you haven't customized these settings before, this won't affect you.</p>
+                        <button id="info-message-close" class="info-message-close" aria-label="Close warning message">×</button>
+                    </div>
+                    
+                    <!-- Recovery info message at the bottom -->
+                    <div class="info-message info">
+                        <span class="info-icon">ℹ️</span>
+                        <p>If ChromaSkin has overwritten important editor or workbench color customizations, you can recover them using the "⋯" menu:
+                        <br>• <strong>Export Original Settings</strong>: Recovers settings from before first theme application
+                        <br>• <strong>Export Previous Settings</strong>: Recovers settings from before latest theme application</p>
                     </div>
                 </div>
             </div>

--- a/media/index.hbs
+++ b/media/index.hbs
@@ -135,19 +135,14 @@
                         <div class="dropdown-menu-container">
                             <button id="menu-button" class="menu-button">⋯</button>
                             <div id="dropdown-menu" class="dropdown-menu">
-                                <div class="dropdown-menu-item" id="export-file">
-                                    <span>Export to file</span>
-                                </div>
-                                <div class="dropdown-menu-item" id="copy-clipboard">
-                                    <span>Copy to clipboard</span>
-                                </div>
+                                <div class="dropdown-menu-item" id="export-file">Export to file</div>
+                                <div class="dropdown-menu-item" id="import-file">Import from file</div>
                                 <div class="dropdown-menu-separator"></div>
-                                <div class="dropdown-menu-item" id="import-file">
-                                    <span>Import from file</span>
-                                </div>
-                                <div class="dropdown-menu-item" id="import-clipboard">
-                                    <span>Import from clipboard</span>
-                                </div>
+                                <div class="dropdown-menu-item" id="copy-clipboard">Copy to clipboard</div>
+                                <div class="dropdown-menu-item" id="import-clipboard">Import from clipboard</div>
+                                <div class="dropdown-menu-separator"></div>
+                                <div class="dropdown-menu-item" id="export-original-settings">Export Original Settings</div>
+                                <div class="dropdown-menu-item" id="export-previous-settings">Export Previous Settings</div>
                             </div>
                         </div>
                         <input type="file" id="import-file-input" accept=".json" style="display: none;" />

--- a/media/index.hbs
+++ b/media/index.hbs
@@ -136,7 +136,6 @@
                                 <div class="dropdown-menu-item" id="import-clipboard">Import from clipboard</div>
                                 <div class="dropdown-menu-separator"></div>
                                 <div class="dropdown-menu-item" id="export-original-settings">Export Original Settings</div>
-                                <div class="dropdown-menu-item" id="export-previous-settings">Export Previous Settings</div>
                             </div>
                         </div>
                         <input type="file" id="import-file-input" accept=".json" style="display: none;" />
@@ -153,8 +152,7 @@
                     <div class="info-message info">
                         <span class="info-icon">ℹ️</span>
                         <p>If ChromaSkin has overwritten important editor or workbench color customizations, you can recover them using the "⋯" menu:
-                        <br>• <strong>Export Original Settings</strong>: Recovers settings from before first theme application
-                        <br>• <strong>Export Previous Settings</strong>: Recovers settings from before latest theme application</p>
+                        <br/><br/>* <strong>Export Original Settings</strong>: Recovers User JSON settings from before first theme application
                     </div>
                 </div>
             </div>

--- a/media/script.js
+++ b/media/script.js
@@ -142,6 +142,10 @@
 
 		// Setup listeners for automatically saving configuration on change
 		setupInputChangeListeners();
+
+		// Add settings export buttons to dropdown
+		document.getElementById("export-original-settings").addEventListener("click", exportOriginalSettings);
+		document.getElementById("export-previous-settings").addEventListener("click", exportPreviousSettings);
 	}
 
 	// Apply theme function
@@ -528,6 +532,22 @@
 		vscode.postMessage({
 			command: "saveCurrentState",
 			themeConfig: themeConfig,
+		});
+	}
+
+	// Function to export original settings
+	function exportOriginalSettings() {
+		document.getElementById("dropdown-menu").classList.remove("active");
+		vscode.postMessage({
+			command: "exportOriginalSettings",
+		});
+	}
+
+	// Function to export previous settings
+	function exportPreviousSettings() {
+		document.getElementById("dropdown-menu").classList.remove("active");
+		vscode.postMessage({
+			command: "exportPreviousSettings",
 		});
 	}
 })();

--- a/media/styles.css
+++ b/media/styles.css
@@ -468,6 +468,7 @@ input[type="checkbox"]:checked {
 }
 
 .info-message.warning {
+	margin-top: 15px;
 	background-color: rgba(255, 166, 0, 0.05);
 	padding: 10px 15px;
 	padding-right: 40px;
@@ -715,6 +716,29 @@ input[type="checkbox"]:checked {
 
 .user-theme-item {
 	position: relative;
+}
+
+.info-message.info {
+    background-color: rgba(0, 120, 215, 0.05);
+    padding: 10px 15px;
+    margin-top: 15px;
+    margin-bottom: 5px;
+    border-radius: 8px;
+	border: 1px solid rgba(0, 118, 215, 0.288);
+	color: color-mix(in srgb, var(--vscode-foreground) 80%, rgba(0, 118, 215, 0.651));
+    display: flex;
+    align-items: flex-start;
+    opacity: 0.9;
+	pointer-events: none;
+}
+
+.info-message.info:hover {
+    opacity: 1;
+}
+
+.info-icon {
+    margin-right: 10px;
+    font-size: 18px;
 }
 
 /* Add responsive adjustments */

--- a/media/styles.css
+++ b/media/styles.css
@@ -470,6 +470,7 @@ input[type="checkbox"]:checked {
 .info-message.warning {
 	margin-top: 15px;
 	background-color: rgba(255, 166, 0, 0.05);
+	border: 1px solid rgba(255, 166, 0, 0.2);
 	padding: 10px 15px;
 	padding-right: 40px;
 	margin-bottom: 15px;
@@ -508,8 +509,9 @@ input[type="checkbox"]:checked {
 	font-weight: bold;
 	cursor: pointer;
 	padding: 0;
-	width: 24px;
-	height: 24px;
+	width: 28px;
+	height: 28px;
+	font-size: 24px;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "chromaskin-by-bator",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "chromaskin-by-bator",
-			"version": "1.1.2",
+			"version": "1.1.3",
 			"license": "MIT",
 			"dependencies": {
 				"handlebars": "^4.7.8"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "chromaskin-by-bator",
 	"displayName": "ChromaSkin",
 	"description": "Mix & Match VS Code Syntax Highlighting with Custom UI",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"publisher": "GergelyBator",
 	"license": "MIT",
 	"repository": {

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -228,7 +228,7 @@ export function getColors(provided: ThemeConfig) {
 	// Git
 	const gitOpacity = 0.7;
 	const git = {
-		ignoredResourceForeground: hexToHexAlpha(foreground, 0.25),
+		ignoredResourceForeground: hexToHexAlpha(foreground, 0.35),
 		modifiedResourceForeground: blendColors(defaults.other.orange.default, foreground, gitOpacity),
 		deletedResourceForeground: blendColors(defaults.other.red.default, foreground, gitOpacity),
 		untrackedResourceForeground: blendColors(defaults.other.green.default, foreground, gitOpacity),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { ThemeConfig } from "./types";
 import { getTokenColorCustomizations } from "./tokenizer";
 import themes, { getPredefinedTheme } from "./themes";
 import { UserThemeManager } from "./userThemes";
+import { UserSettingsManager } from "./userSettingsManager";
 
 class ChromaSkinExtension {
 	private activePanel: vscode.WebviewPanel | undefined;
@@ -17,10 +18,12 @@ class ChromaSkinExtension {
 	private isPanelActivePrev: boolean = false;
 	private readonly DEFAULT_THEME_CONFIG: ThemeConfig = themes["default"][0].config;
 	private userThemeManager: UserThemeManager;
+	private userSettingsManager: UserSettingsManager;
 
 	constructor(context: vscode.ExtensionContext) {
 		this.context = context;
 		this.userThemeManager = new UserThemeManager(context);
+		this.userSettingsManager = new UserSettingsManager(context);
 	}
 
 	private isDevMode(): boolean {
@@ -28,7 +31,7 @@ class ChromaSkinExtension {
 	}
 
 	private clearAllGlobalState() {
-		console.log("ChromaSkin: Clearing all global state!");
+		console.log("ChromaSkin: Clearing all global state (except initial settings)!");
 		this.context.globalState.update("chromaskin-theme-config", null);
 		this.context.globalState.update("chromaskin-theme-config-unapplied", null);
 		this.context.globalState.update("chromaskin-hide-info-message", null);
@@ -67,7 +70,97 @@ class ChromaSkinExtension {
 		this.activePanel.webview.html = this.getWebviewContent(this.context, this.activePanel.webview, theme);
 
 		this.activePanel.webview.onDidReceiveMessage(
-			(message) => this.handleWebviewMessage(message),
+			async (message) => {
+				switch (message.command) {
+					case "applyTheme":
+						this.applyColorTheme(message.themeConfig);
+						vscode.window.showInformationMessage("ChromaSkin: Custom Theme Applied! 🎨");
+						break;
+					case "applyPredefinedTheme":
+						const { config } = getPredefinedTheme(message.category, message.index);
+						this.applyColorTheme(config);
+						vscode.window.showInformationMessage("ChromaSkin: Predefined Theme Applied! 🎨");
+						break;
+					case "resetTheme":
+						this.resetColorTheme();
+						vscode.window.showInformationMessage("ChromaSkin: Theme Reset! 🔄");
+						break;
+					case "resetColors":
+						this.resetColors();
+						vscode.window.showInformationMessage("ChromaSkin: Colors Reset! 🔄");
+						break;
+					case "exportTheme":
+						this.exportTheme(message.themeConfig);
+						vscode.window.showInformationMessage("ChromaSkin: Theme Exported! 📤");
+						break;
+					case "importTheme":
+						this.importTheme(message.themeConfig);
+						vscode.window.showInformationMessage("ChromaSkin: Theme Imported! 📥");
+						break;
+					case "showError":
+						vscode.window.showErrorMessage(`ChromaSkin: ${message.message}`);
+						break;
+					case "showInfo":
+						vscode.window.showInformationMessage(`ChromaSkin: ${message.message}`);
+						break;
+					case "hideInfoMessage":
+						console.log("ChromaSkin: GOT HIDING INFO MESSAGE!");
+						this.context.globalState.update("chromaskin-hide-info-message", true);
+						break;
+					case "saveUserTheme":
+						const savedTheme = this.userThemeManager.saveTheme(message.name, message.description, message.themeConfig);
+						this.reloadWebview();
+						vscode.window.showInformationMessage(`ChromaSkin: Theme "${message.name}" saved! 💾`);
+						break;
+					case "deleteUserTheme":
+						const deleted = this.userThemeManager.deleteTheme(message.themeId);
+						if (deleted) {
+							this.reloadWebview();
+							vscode.window.showInformationMessage(`ChromaSkin: Theme deleted! 🗑️`);
+						}
+						break;
+					case "applyUserTheme":
+						const theme = this.userThemeManager.getTheme(message.themeId);
+						if (theme) {
+							this.applyColorTheme(theme.config);
+							vscode.window.showInformationMessage("ChromaSkin: Saved Theme Applied! 🎨");
+						} else {
+							vscode.window.showErrorMessage("ChromaSkin: Theme not found! 🚫");
+						}
+						break;
+					case "confirmDeleteTheme": {
+						const themeId = message.themeId;
+						vscode.window
+							.showWarningMessage("Are you sure you want to delete this theme?", "Delete", "Cancel")
+							.then((selection) => {
+								if (selection === "Delete") {
+									this.userThemeManager.deleteTheme(themeId);
+									this.reloadWebview();
+									vscode.window.showInformationMessage("ChromaSkin: Theme deleted! 🗑️");
+								}
+							});
+						break;
+					}
+					case "saveCurrentState":
+						// Save the current state without applying it as a theme
+						this.saveCurrentState(message.themeConfig);
+						break;
+					case "exportOriginalSettings":
+						this.exportOriginalSettings();
+						break;
+					case "exportPreviousSettings":
+						const prevSettings = this.userSettingsManager.getPreviousSettings();
+						if (prevSettings) {
+							const document = JSON.stringify(prevSettings, null, 2);
+							vscode.workspace
+								.openTextDocument({ content: document, language: "json" })
+								.then((doc) => vscode.window.showTextDocument(doc));
+						} else {
+							vscode.window.showInformationMessage("No previous settings found.");
+						}
+						break;
+				}
+			},
 			undefined,
 			this.context.subscriptions
 		);
@@ -99,83 +192,13 @@ class ChromaSkinExtension {
 		});
 	}
 
-	private handleWebviewMessage(message: any) {
-		switch (message.command) {
-			case "applyTheme":
-				this.applyColorTheme(message.themeConfig);
-				vscode.window.showInformationMessage("ChromaSkin: Custom Theme Applied! 🎨");
-				break;
-			case "applyPredefinedTheme":
-				const { config } = getPredefinedTheme(message.category, message.index);
-				this.applyColorTheme(config);
-				vscode.window.showInformationMessage("ChromaSkin: Predefined Theme Applied! 🎨");
-				break;
-			case "resetTheme":
-				this.resetColorTheme();
-				vscode.window.showInformationMessage("ChromaSkin: Theme Reset! 🔄");
-				break;
-			case "resetColors":
-				this.resetColors();
-				vscode.window.showInformationMessage("ChromaSkin: Colors Reset! 🔄");
-				break;
-			case "exportTheme":
-				this.exportTheme(message.themeConfig);
-				vscode.window.showInformationMessage("ChromaSkin: Theme Exported! 📤");
-				break;
-			case "importTheme":
-				this.importTheme(message.themeConfig);
-				vscode.window.showInformationMessage("ChromaSkin: Theme Imported! 📥");
-				break;
-			case "showError":
-				vscode.window.showErrorMessage(`ChromaSkin: ${message.message}`);
-				break;
-			case "showInfo":
-				vscode.window.showInformationMessage(`ChromaSkin: ${message.message}`);
-				break;
-			case "hideInfoMessage":
-				console.log("ChromaSkin: GOT HIDING INFO MESSAGE!");
-				this.context.globalState.update("chromaskin-hide-info-message", true);
-				break;
-			case "saveUserTheme":
-				const savedTheme = this.userThemeManager.saveTheme(message.name, message.description, message.themeConfig);
-				this.reloadWebview();
-				vscode.window.showInformationMessage(`ChromaSkin: Theme "${message.name}" saved! 💾`);
-				break;
-			case "deleteUserTheme":
-				const deleted = this.userThemeManager.deleteTheme(message.themeId);
-				if (deleted) {
-					this.reloadWebview();
-					vscode.window.showInformationMessage(`ChromaSkin: Theme deleted! 🗑️`);
-				}
-				break;
-			case "applyUserTheme":
-				const theme = this.userThemeManager.getTheme(message.themeId);
-				if (theme) {
-					this.applyColorTheme(theme.config);
-					vscode.window.showInformationMessage("ChromaSkin: Saved Theme Applied! 🎨");
-				} else {
-					vscode.window.showErrorMessage("ChromaSkin: Theme not found! 🚫");
-				}
-				break;
-			case "confirmDeleteTheme": {
-				const themeId = message.themeId;
-				vscode.window.showWarningMessage("Are you sure you want to delete this theme?", "Delete", "Cancel").then((selection) => {
-					if (selection === "Delete") {
-						this.userThemeManager.deleteTheme(themeId);
-						this.reloadWebview();
-						vscode.window.showInformationMessage("ChromaSkin: Theme deleted! 🗑️");
-					}
-				});
-				break;
-			}
-			case "saveCurrentState":
-				// Save the current state without applying it as a theme
-				this.saveCurrentState(message.themeConfig);
-				break;
-		}
-	}
-
 	private applyColorTheme(themeConfig: ThemeConfig, saveConfig: boolean = true) {
+		// Save initial settings before applying first theme
+		this.userSettingsManager.saveInitialSettings();
+
+		// Save current settings before applying new theme
+		this.userSettingsManager.saveCurrentSettings();
+
 		// Store current breadcrumbs state before changing it
 		this.previousBreadcrumbsState = vscode.workspace.getConfiguration("breadcrumbs").get("enabled");
 
@@ -216,8 +239,10 @@ class ChromaSkinExtension {
 	}
 
 	private resetColorTheme() {
-		vscode.workspace.getConfiguration("workbench").update("colorCustomizations", {}, vscode.ConfigurationTarget.Global);
-		vscode.workspace.getConfiguration("editor").update("tokenColorCustomizations", {}, vscode.ConfigurationTarget.Global);
+		// Restore initial user settings
+		this.userSettingsManager.restoreInitialSettings();
+		// vscode.workspace.getConfiguration("workbench").update("colorCustomizations", {}, vscode.ConfigurationTarget.Global);
+		// vscode.workspace.getConfiguration("editor").update("tokenColorCustomizations", {}, vscode.ConfigurationTarget.Global);
 
 		// Restore breadcrumbs to previous state if it was previously stored
 		if (this.previousBreadcrumbsState !== undefined) {
@@ -312,6 +337,19 @@ class ChromaSkinExtension {
 		// Only save to global state, don't apply to VS Code's theme
 		this.context.globalState.update("chromaskin-theme-config-unapplied", themeConfig);
 		console.log("ChromaSkin: Current state saved");
+	}
+
+	private exportOriginalSettings() {
+		const initialSettings = this.userSettingsManager.getInitialSettings();
+
+		if (!initialSettings) {
+			vscode.window.showInformationMessage("No original settings found.");
+			return;
+		}
+
+		// Show JSON in a new document
+		const document = JSON.stringify(initialSettings, null, 2);
+		vscode.workspace.openTextDocument({ content: document, language: "json" }).then((doc) => vscode.window.showTextDocument(doc));
 	}
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,11 +30,16 @@ class ChromaSkinExtension {
 		return this.context.extensionMode === vscode.ExtensionMode.Development;
 	}
 
+	/**
+	 * !IMPORTANT: This is only used in development mode to clear the global state before the extension is activated
+	 * For production, we don't need to clear the global state, because the extension is activated on every VS Code startup
+	 */
 	private clearAllGlobalState() {
-		console.log("ChromaSkin: Clearing all global state (except initial settings)!");
+		console.log("ChromaSkin: Clearing all global state (including initial user settings)!");
 		this.context.globalState.update("chromaskin-theme-config", null);
 		this.context.globalState.update("chromaskin-theme-config-unapplied", null);
 		this.context.globalState.update("chromaskin-hide-info-message", null);
+		this.userSettingsManager.clearAllGlobalState();
 	}
 
 	public activate() {
@@ -193,10 +198,7 @@ class ChromaSkinExtension {
 	}
 
 	private applyColorTheme(themeConfig: ThemeConfig, saveConfig: boolean = true) {
-		// Save initial settings before applying first theme
 		this.userSettingsManager.saveInitialSettings();
-
-		// Save current settings before applying new theme
 		this.userSettingsManager.saveCurrentSettings();
 
 		// Store current breadcrumbs state before changing it
@@ -206,13 +208,22 @@ class ChromaSkinExtension {
 		const { data: colorCustomizations, theme } = generateWorkbenchTheme(themeConfig);
 		const tokenColorCustomizations = getTokenColorCustomizations(themeConfig);
 
+		const currentColorCustomizations = this.userSettingsManager.getCurrentColorSettings();
+		const currentTextMateRules = (currentColorCustomizations.tokenColorCustomizations as any)?.textMateRules || [];
+
 		// update configurations
 		vscode.workspace
 			.getConfiguration("workbench")
 			.update("colorCustomizations", colorCustomizations, vscode.ConfigurationTarget.Global);
-		vscode.workspace
-			.getConfiguration("editor")
-			.update("tokenColorCustomizations", tokenColorCustomizations, vscode.ConfigurationTarget.Global);
+		vscode.workspace.getConfiguration("editor").update(
+			"tokenColorCustomizations",
+			{
+				...(currentColorCustomizations.tokenColorCustomizations || {}),
+				...tokenColorCustomizations,
+				textMateRules: [...currentTextMateRules, ...tokenColorCustomizations.textMateRules],
+			},
+			vscode.ConfigurationTarget.Global
+		);
 		// Hide breadcrumbs
 		vscode.workspace.getConfiguration("breadcrumbs").update("enabled", false, vscode.ConfigurationTarget.Global);
 
@@ -240,9 +251,7 @@ class ChromaSkinExtension {
 
 	private resetColorTheme() {
 		// Restore initial user settings
-		this.userSettingsManager.restoreInitialSettings();
-		// vscode.workspace.getConfiguration("workbench").update("colorCustomizations", {}, vscode.ConfigurationTarget.Global);
-		// vscode.workspace.getConfiguration("editor").update("tokenColorCustomizations", {}, vscode.ConfigurationTarget.Global);
+		this.userSettingsManager.restorePreviousSettings();
 
 		// Restore breadcrumbs to previous state if it was previously stored
 		if (this.previousBreadcrumbsState !== undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -252,6 +252,7 @@ class ChromaSkinExtension {
 	private resetColorTheme() {
 		// Restore initial user settings
 		this.userSettingsManager.restorePreviousSettings();
+		
 
 		// Restore breadcrumbs to previous state if it was previously stored
 		if (this.previousBreadcrumbsState !== undefined) {

--- a/src/userSettingsManager.ts
+++ b/src/userSettingsManager.ts
@@ -1,0 +1,111 @@
+import * as vscode from "vscode";
+
+/**
+ * Interface to store both workbench color customizations and token color customizations
+ */
+export interface UserColorSettings {
+	workbenchColorCustomizations?: object;
+	tokenColorCustomizations?: object;
+}
+
+/**
+ * Manages the user's color customization settings, preserving original state
+ * and allowing restoration of previous settings
+ */
+export class UserSettingsManager {
+	private context: vscode.ExtensionContext;
+	private static readonly INITIAL_SETTINGS_KEY = "chromaskin-initial-settings";
+	private static readonly PREVIOUS_SETTINGS_KEY = "chromaskin-previous-settings";
+
+	constructor(context: vscode.ExtensionContext) {
+		this.context = context;
+	}
+
+	/**
+	 * Saves the user's current color settings before first theme application
+	 * Only saves if settings haven't been saved before
+	 */
+	public saveInitialSettings(): void {
+		// Only save initial settings if they don't exist yet
+		if (!this.context.globalState.get(UserSettingsManager.INITIAL_SETTINGS_KEY)) {
+			const currentSettings = this.getCurrentColorSettings();
+			this.context.globalState.update(UserSettingsManager.INITIAL_SETTINGS_KEY, currentSettings);
+			console.log("ChromaSkin: Initial user settings saved");
+		}
+	}
+
+	/**
+	 * Saves the user's current color settings before applying a new theme
+	 */
+	public saveCurrentSettings(): void {
+		const currentSettings = this.getCurrentColorSettings();
+		this.context.globalState.update(UserSettingsManager.PREVIOUS_SETTINGS_KEY, currentSettings);
+		console.log("ChromaSkin: Current user settings saved");
+	}
+
+	/**
+	 * Gets the user's current color customization settings from VS Code configuration
+	 */
+	private getCurrentColorSettings(): UserColorSettings {
+		const config = vscode.workspace.getConfiguration();
+
+		return {
+			workbenchColorCustomizations: config.get("workbench.colorCustomizations"),
+			tokenColorCustomizations: config.get("editor.tokenColorCustomizations"),
+		};
+	}
+
+	/**
+	 * Gets the user's initial saved settings (before any theme was applied)
+	 */
+	public getInitialSettings(): UserColorSettings | undefined {
+		return this.context.globalState.get<UserColorSettings>(UserSettingsManager.INITIAL_SETTINGS_KEY);
+	}
+
+	/**
+	 * Gets the user's previously saved settings
+	 */
+	public getPreviousSettings(): UserColorSettings | undefined {
+		return this.context.globalState.get<UserColorSettings>(UserSettingsManager.PREVIOUS_SETTINGS_KEY);
+	}
+
+	/**
+	 * Restores the user's initial color settings
+	 */
+	public async restoreInitialSettings(): Promise<void> {
+		const initialSettings = this.getInitialSettings();
+		if (initialSettings) {
+			const config = vscode.workspace.getConfiguration();
+
+			await config.update(
+				"workbench.colorCustomizations",
+				initialSettings.workbenchColorCustomizations,
+				vscode.ConfigurationTarget.Global
+			);
+
+			await config.update(
+				"editor.tokenColorCustomizations",
+				initialSettings.tokenColorCustomizations,
+				vscode.ConfigurationTarget.Global
+			);
+
+			console.log("ChromaSkin: Initial user settings restored");
+		} else {
+			// If there are no initial settings, just clear everything
+			this.clearColorSettings();
+		}
+	}
+
+	/**
+	 * Clears all color customization settings
+	 */
+	private async clearColorSettings(): Promise<void> {
+		const config = vscode.workspace.getConfiguration();
+
+		await config.update("workbench.colorCustomizations", {}, vscode.ConfigurationTarget.Global);
+
+		await config.update("editor.tokenColorCustomizations", {}, vscode.ConfigurationTarget.Global);
+
+		console.log("ChromaSkin: Color settings cleared");
+	}
+}

--- a/src/userSettingsManager.ts
+++ b/src/userSettingsManager.ts
@@ -47,9 +47,19 @@ export class UserSettingsManager {
 	 * Saves the user's current color settings before applying a new theme
 	 */
 	public saveCurrentSettings(): void {
-		const currentSettings = this.getCurrentColorSettings();
-		this.context.globalState.update(UserSettingsManager.PREVIOUS_SETTINGS_KEY, currentSettings);
-		console.log("ChromaSkin: Current user settings saved");
+		if (!this.context.globalState.get(UserSettingsManager.PREVIOUS_SETTINGS_KEY)) {
+			const currentSettings = this.getCurrentColorSettings();
+			this.context.globalState.update(UserSettingsManager.PREVIOUS_SETTINGS_KEY, currentSettings);
+			console.log("ChromaSkin: Current user settings saved");
+		}
+	}
+
+	/**
+	 * Clears the current user settings
+	 */
+	public clearPreviousSettings(): void {
+		this.context.globalState.update(UserSettingsManager.PREVIOUS_SETTINGS_KEY, null);
+		console.log("ChromaSkin: Previous user settings cleared");
 	}
 
 	/**
@@ -125,10 +135,8 @@ export class UserSettingsManager {
 				vscode.ConfigurationTarget.Global
 			);
 
+			this.clearPreviousSettings()
 			console.log("ChromaSkin: Previous user settings restored");
-		} else {
-			// If there are no previous settings, just clear everything
-			this.clearColorSettings();
 		}
 	}
 

--- a/src/userSettingsManager.ts
+++ b/src/userSettingsManager.ts
@@ -22,6 +22,15 @@ export class UserSettingsManager {
 	}
 
 	/**
+	 * Clears all global state
+	 * !IMPORTANT: This is only used in development mode to clear the global state before the extension is activated
+	 */
+	public clearAllGlobalState(): void {
+		this.context.globalState.update(UserSettingsManager.INITIAL_SETTINGS_KEY, null);
+		this.context.globalState.update(UserSettingsManager.PREVIOUS_SETTINGS_KEY, null);
+	}
+
+	/**
 	 * Saves the user's current color settings before first theme application
 	 * Only saves if settings haven't been saved before
 	 */
@@ -46,7 +55,7 @@ export class UserSettingsManager {
 	/**
 	 * Gets the user's current color customization settings from VS Code configuration
 	 */
-	private getCurrentColorSettings(): UserColorSettings {
+	public getCurrentColorSettings(): UserColorSettings {
 		const config = vscode.workspace.getConfiguration();
 
 		return {
@@ -92,6 +101,33 @@ export class UserSettingsManager {
 			console.log("ChromaSkin: Initial user settings restored");
 		} else {
 			// If there are no initial settings, just clear everything
+			this.clearColorSettings();
+		}
+	}
+
+	/**
+	 * Restores the user's previous color settings
+	 */
+	public async restorePreviousSettings(): Promise<void> {
+		const previousSettings = this.getPreviousSettings();
+		if (previousSettings) {
+			const config = vscode.workspace.getConfiguration();
+
+			await config.update(
+				"workbench.colorCustomizations",
+				previousSettings.workbenchColorCustomizations,
+				vscode.ConfigurationTarget.Global
+			);
+
+			await config.update(
+				"editor.tokenColorCustomizations",
+				previousSettings.tokenColorCustomizations,
+				vscode.ConfigurationTarget.Global
+			);
+
+			console.log("ChromaSkin: Previous user settings restored");
+		} else {
+			// If there are no previous settings, just clear everything
 			this.clearColorSettings();
 		}
 	}


### PR DESCRIPTION
- [x] feat: save user color-token color customizations ✅ 2025-04-29
	- [x] allow export of these settings ✅ 2025-04-29
	- [x] show information about where and how to recover these ✅ 2025-04-29
- [x] dont completely overwrite tokenColorcutomizations -> apply it with them ✅ 2025-04-29
- [x] gitignore files less opacity ✅ 2025-04-29